### PR TITLE
Add compatibility for classNames

### DIFF
--- a/src/Col.re
+++ b/src/Col.re
@@ -15,6 +15,7 @@ let make =
       ~smOffset=?,
       ~mdOffset=?,
       ~lgOffset=?,
+      ~className="",
     ) => {
   let totalOptions =
     [|
@@ -29,6 +30,7 @@ let make =
       breakpointedProp("col", fluid),
       breakpointedProp("first", first),
       breakpointedProp("last", last),
+      className,
     |]
     |> Js.Array.joinWith("  ");
 

--- a/src/FlexboxGridDemo.re
+++ b/src/FlexboxGridDemo.re
@@ -18,6 +18,35 @@ module Box = {
     </div>;
   };
 };
+module BsCss = {
+  open Css;
+  let rowStyle =
+    style([
+      backgroundColor(`rgba((0, 0, 0, 0.2))),
+      padding2(~v=0.5->rem, ~h=0.5->rem),
+    ]);
+  let colStyle =
+    style([
+      backgroundColor(`rgba((0, 0, 0, 0.2))),
+      borderColor(`rgba((0, 0, 0, 0.2))),
+      borderWidth(1->px),
+      borderStyle(`solid),
+      padding2(~v=0.5->rem, ~h=0.5->rem),
+    ]);
+  [@react.component]
+  let make = () => {
+    <>
+      <h1> "Bs-Css Compatibility"->React.string </h1>
+      <p> "Add extra styles with the className tag"->React.string </p>
+      <Row className=rowStyle>
+        <Col className=colStyle xs=3> "1"->React.string </Col>
+        <Col className=colStyle xs=3> "2"->React.string </Col>
+        <Col className=colStyle xs=3> "3"->React.string </Col>
+        <Col className=colStyle xs=3> "4"->React.string </Col>
+      </Row>
+    </>;
+  };
+};
 module Alignment = {
   [@react.component]
   let make = () => {

--- a/src/Index.re
+++ b/src/Index.re
@@ -2,6 +2,7 @@ open FlexboxGridDemo;
 
 ReactDOMRe.renderToElementWithId(
   <>
+    <BsCss />
     <Responsive />
     <Fluid />
     <Offsets />

--- a/src/Row.re
+++ b/src/Row.re
@@ -13,6 +13,7 @@ let make =
       ~around=`none,
       ~between=`none,
       ~reverse=false,
+      ~className="",
     ) => {
   let totalOptions =
     [|
@@ -26,6 +27,7 @@ let make =
       breakpointedProp("around", around),
       breakpointedProp("between", between),
       booleanProp("reverse", reverse),
+      className,
     |]
     |> Js.Array.joinWith("  ");
   <div className=totalOptions> children </div>;


### PR DESCRIPTION
This makes it possible to either directly add classNames, or use bs-css from the outside. Classnames are appended, making it possible to override flexboxgrid things if need be.